### PR TITLE
sys: mv ingress into example

### DIFF
--- a/base/grafana.yaml
+++ b/base/grafana.yaml
@@ -1,17 +1,3 @@
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: grafana
-spec:
-  rules:
-    - host: demo-grafana.com
-      http:
-        paths:
-          - backend:
-              serviceName: grafana
-              servicePort: 3000
-            path: /
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/example/grafana-ingress.yaml
+++ b/example/grafana-ingress.yaml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: grafana
+spec:
+  rules:
+    - host: demo-grafana.com
+      http:
+        paths:
+          - backend:
+              serviceName: grafana
+              servicePort: 3000
+            path: /

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 bases:
   - ../base/
 #  - github.com/utilitywarehouse/grafana-manifests/base?ref=v1.0.11
+resources:
+  - grafana-ingress.yaml
 patchesStrategicMerge:
   - grafana.yaml
   - grafana-google-auth.yaml


### PR DESCRIPTION
Ingress is too specific to be useful inside the base. New class of
Ingres Controllers prefer CRDs over vanialla Ingress, so its even less
useful.