### PR TITLE
Upgrade Grafana v9.3.4

### DIFF
--- a/base/grafana.yaml
+++ b/base/grafana.yaml
@@ -41,7 +41,7 @@ spec:
         fsGroup: 65533 # to make SSH key readable
       containers:
         - name: grafana
-          image: grafana/grafana:9.1.4
+          image: grafana/grafana:9.3.4
           env:
             - name: GF_SERVER_ROOT_URL
               value: https://demo-grafana.com


### PR DESCRIPTION
The main aim here is to enable the use of TraceQL. While the minimum for that is v9.3.1, there are numerous important bug fixes post that release.

Also pulls in important Loki/Tempo bug fixes.