### PR TITLE
Update grafana settings

### DIFF
--- a/base/grafana.yaml
+++ b/base/grafana.yaml
@@ -45,45 +45,26 @@ spec:
           env:
             - name: GF_SERVER_ROOT_URL
               value: https://demo-grafana.com
+            - name: GF_SERVER_ENABLE_GZIP
+              value: "true"
             - name: GF_PATHS_DATA
               value: /data
             - name: GF_PATHS_PLUGINS
               value: /data/plugins
             - name: GF_PATHS_PROVISIONING
               value: /provisioning
-            - name: GF_SECURITY_ALLOW_EMBEDDING
-              value: "true"
-            - name: GF_SECURITY_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: admin-password
-                  name: grafana-secrets
-            - name: GF_USERS_AUTO_ASSIGN_ORG_ROLE
-              value: "Admin"
-            - name: GF_USERS_ALLOW_SIGN_UP
-              value: "false"
-            - name: GF_USERS_ALLOW_ORG_CREATE
-              value: "false"
-            - name: GF_AUTH_DISABLE_LOGIN_FORM
-              value: "true"
-            - name: GF_AUTH_ANONYMOUS_ENABLED
-              value: "true"
             - name: GF_ANALYTICS_REPORTING_ENABLED
-              value: "false"
-            - name: GF_ALERTING_ENABLED
-              value: "false"
-            - name: GF_SMTP_ENABLED
               value: "false"
             - name: GF_LOG_MODE
               value: console
+            - name: GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION
+              value: "true"
+            - name: GF_AUTH_DISABLE_LOGIN_FORM
+              value: "true"
+            - name: GF_USERS_AUTO_ASSIGN_ORG_ROLE
+              value: "Editor"
             - name: GF_INSTALL_PLUGINS
               value: grafana-piechart-panel,grafana-clock-panel
-            - name: GF_SERVER_ENABLE_GZIP
-              value: "true"
-            - name: GF_METRICS_ENABLED
-              value: "true"
-            - name: GF_EXPLORE_ENABLED
-              value: "true"
           ports:
             - containerPort: 3000
               name: web

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -17,7 +17,6 @@ secretGenerator:
   - name: grafana-secrets
     type: Opaque
     files:
-      - admin-password=secrets/grafana-admin-password
       - git-ssh-key=secrets/grafana-git-ssh-key
       - known_hosts=secrets/grafana-known_hosts
   - name: grafana-google-auth

--- a/example/secrets/grafana-admin-password
+++ b/example/secrets/grafana-admin-password
@@ -1,1 +1,0 @@
-example


### PR DESCRIPTION
* default OAuth users' role to Editor instead of Admin, which restricts datasource creation, which can be used to access restricted endpoints, given how grafana's namespace usually has network access to many places to gather metrics
* disable initial admin user, which we don't use and forces a secret
* stop allowing embedding, which we don't need anymore (it was used for the TV dashboards in NHQ)
* remove entries that are already defaults