### PR TITLE
Update to v11.5.1

### DIFF
--- a/base/grafana.yaml
+++ b/base/grafana.yaml
@@ -41,7 +41,7 @@ spec:
         fsGroup: 65533 # to make SSH key readable
       containers:
         - name: grafana
-          image: grafana/grafana:11.3.1
+          image: grafana/grafana:11.5.1
           env:
             - name: GF_SERVER_ROOT_URL
               value: https://demo-grafana.com


### PR DESCRIPTION
Bunch of changes that impact Tempo, specifically after use of the new v2 API that came in around v11.4, however bumping to latest Grafana version at time of raising this PR.

Note: Grafana Cloud is currently running v11.5.0